### PR TITLE
feature: check the goa design on every commit

### DIFF
--- a/.github/workflows/check-goa-generate.yaml
+++ b/.github/workflows/check-goa-generate.yaml
@@ -1,0 +1,21 @@
+name: Check if Goa can generate a design
+on: [push]
+jobs:
+  goa-generate:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout repo
+      uses: actions/checkout@v2
+    - name: setup Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.17'
+    - name: install Protoc
+      uses: arduino/setup-protoc@v1 
+    - name: install Goa
+      run: make install-goa
+    - name: generate Goa design
+      run: make generate
+    - name: everything builds
+      run: go build ./...
+        

--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,9 @@
 
 generate:
 	goa gen github.com/allinbits/sdk-service-meta
+
+install-goa:
+	go get -u goa.design/goa/v3
+	go get -u goa.design/goa/v3/...
+	go install -v github.com/golang/protobuf/protoc-gen-go@latest
+	go install -v google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest


### PR DESCRIPTION
This pr adds a github action that executes `goa generate' and `go build` on each commit, useful to catch weird DSL bugs.